### PR TITLE
Feature/enhanced route decorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,137 @@
-*.pyc
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+.static_storage/
+.media/
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# JetBrains
+
+.idea

--- a/bottleCBV.py
+++ b/bottleCBV.py
@@ -47,6 +47,12 @@ class route(object):
 
     @staticmethod
     def get(rule):
+        """
+        GET Method
+        CRUD Use Case: Read
+        Example:
+          Request a user profile
+        """
         options = dict(method='GET')
 
         def decorator(f):
@@ -56,6 +62,12 @@ class route(object):
 
     @staticmethod
     def post(rule):
+        """
+        POST Method
+        CRUD Use Case: Create
+        Example:
+          Create a new user
+        """
         options = dict(method='POST')
 
         def decorator(f):
@@ -65,6 +77,12 @@ class route(object):
 
     @staticmethod
     def put(rule):
+        """
+        PUT Method
+        CRUD Use Case: Update / Replace
+        Example:
+          Set item# 4022 to Red Seedless Grapes, instead of tomatoes
+        """
         options = dict(method='PUT')
 
         def decorator(f):
@@ -73,7 +91,28 @@ class route(object):
         return decorator
 
     @staticmethod
+    def patch(rule):
+        """
+        PATCH Method
+        CRUD Use Case: Update / Modify
+        Example:
+          Rename then user's name from Jon to John
+        """  
+        options = dict(method='PATCH')
+
+        def decorator(f):
+            return route.decorate(f, rule, **options)
+
+        return decorator
+
+    @staticmethod
     def delete(rule):
+        """
+        DELETE Method
+        CRUD Use Case: Delete
+        Example:
+          Delete user# 12403 (John)
+        """
         options = dict(method='DELETE')
 
         def decorator(f):
@@ -83,16 +122,20 @@ class route(object):
 
     @staticmethod
     def head(rule):
-        options = dict(method='HEAD')
-
-        def decorator(f):
-            return route.decorate(f, rule, **options)
-
-        return decorator
+        """
+        HEAD Method
+        CRUD Use Case: Read (in-part)
+        Note: This is the same as GET, but without the response body.
         
-    @staticmethod
-    def patch(rule):
-        options = dict(method='PATCH')
+        This is useful for items such as checking if a user exists, such as this example:
+          Request: GET /user/12403
+          Response: (status code) 404 - Not Found
+        
+        If you are closely following the REST standard, you can also verify if the requested PATCH (update) was successfully applied, in this example:
+          Request: PUT /user/12404 { "name": "John"}
+          Response: (status code) 304 - Not Modified
+        """
+        options = dict(method='HEAD')
 
         def decorator(f):
             return route.decorate(f, rule, **options)
@@ -101,6 +144,11 @@ class route(object):
 
     @staticmethod
     def any(rule):
+        """
+        From the Bottle Documentation: 
+          
+        The non-standard ANY method works as a low priority fallback: Routes that listen to ANY will match requests regardless of their HTTP method but only if no other more specific route is defined. This is helpful for proxy-routes that redirect requests to more specific sub-applications.
+        """
         options = dict(method='ANY')
         
         def decorator(f):

--- a/bottleCBV.py
+++ b/bottleCBV.py
@@ -89,6 +89,15 @@ class route(object):
             return route.decorate(f, rule, **options)
 
         return decorator
+        
+    @staticmethod
+    def patch(rule):
+        options = dict(method='PATCH')
+
+        def decorator(f):
+            return route.decorate(f, rule, **options)
+
+        return decorator
 
     @staticmethod
     def any(rule):

--- a/bottleCBV.py
+++ b/bottleCBV.py
@@ -7,25 +7,97 @@ _py2 = sys.version_info[0] == 2
 _py3 = sys.version_info[0] == 3
 
 
-def route(rule, **options):
-    """A decorator that is used to define custom routes for methods in
-    BottleView subclasses. The format is exactly the same as Bottle's
-    `@app.route` decorator.
+class route(object):
+    def __init__(self, rule, **options):
+        """
+    Class Initializer - This will only execute if using BottleCBV's original route() style.
     """
 
-    def decorator(f):
-        # Put the rule cache on the method itself instead of globally
+        # Not sure if this is needed, need to test what happens when you specify a rule but not options in BottleCBV.
+        if not options:
+            options = dict(method='ANY')
+        self.rule = rule
+        self.options = options
+
+    def __call__(self, func):
+        f = func
+        rule = self.rule
+        options = self.options
+
+        def decorator(*args, **kwargs):
+            if not hasattr(f, '_rule_cache') or f._rule_cache is None:
+                f._rule_cache = {f.__name__: [(rule, options)]}
+            elif not f.__name__ in f._rule_cache:
+                f._rule_cache[f.__name__] = [(rule, options)]
+            else:
+                f._rule_cache[f.__name__].append((rule, options))
+            return f
+
+        return decorator()
+
+    @staticmethod
+    def decorate(f, rule, **options):
         if not hasattr(f, '_rule_cache') or f._rule_cache is None:
             f._rule_cache = {f.__name__: [(rule, options)]}
         elif not f.__name__ in f._rule_cache:
             f._rule_cache[f.__name__] = [(rule, options)]
         else:
             f._rule_cache[f.__name__].append((rule, options))
-
         return f
 
-    return decorator
+    @staticmethod
+    def get(rule):
+        options = dict(method='GET')
 
+        def decorator(f):
+            return route.decorate(f, rule, **options)
+
+        return decorator
+
+    @staticmethod
+    def post(rule):
+        options = dict(method='POST')
+
+        def decorator(f):
+            return route.decorate(f, rule, **options)
+
+        return decorator
+
+    @staticmethod
+    def put(rule):
+        options = dict(method='PUT')
+
+        def decorator(f):
+            return route.decorate(f, rule, **options)
+
+        return decorator
+
+    @staticmethod
+    def delete(rule):
+        options = dict(method='DELETE')
+
+        def decorator(f):
+            return route.decorate(f, rule, **options)
+
+        return decorator
+
+    @staticmethod
+    def head(rule):
+        options = dict(method='HEAD')
+
+        def decorator(f):
+            return route.decorate(f, rule, **options)
+
+        return decorator
+
+    @staticmethod
+    def any(rule):
+        options = dict(method='ANY')
+        
+        def decorator(f):
+            return route.decorate(f, rule, **options)
+
+        return decorator
 
 class BottleView(object):
     """ Class based view implementation for bottle (following flask-classy architech)


### PR DESCRIPTION
Updated route decorator to allow @route.get, @route.post, etc

Updated the route decorator to a class based decorator, allowing the
developer to specify the method without having to a keyword argument
specifying a list.

The bulk of the changes were made under this commit: [fac917e](https://github.com/homecoder/bottleCBV/commit/fac917e5a8b142a6d9eb8505d2606941cf21d7f8)

Example:
```
# This is the new method
@route.get('/example_get')
def example_get(self, *args):
print('GET Example')

@route.post('/example_get')
def example_post(self, *args):
print('POST Example')

# Below is the original functionality.
@route('/still_working', method=['GET','POST'])
def working(self, *args):
print('existing code still works')
```